### PR TITLE
Move getCacheTags from abstract strategy to elastica strategies

### DIFF
--- a/ElasticaFront/DisplayBlock/ElasticaListStrategy.php
+++ b/ElasticaFront/DisplayBlock/ElasticaListStrategy.php
@@ -82,6 +82,16 @@ class ElasticaListStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/ElasticaFront/DisplayBlock/ElasticaSearchStrategy.php
+++ b/ElasticaFront/DisplayBlock/ElasticaSearchStrategy.php
@@ -59,6 +59,16 @@ class ElasticaSearchStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string


### PR DESCRIPTION
[OO-BCBREAK] DisplayBundle/DisplayBlock/Strategies/AbstractStrategy:getCacheTags() is now abstract and must therefore be explicitally implemented on each display strategy
https://github.com/open-orchestra/open-orchestra-display-bundle/pull/200
https://github.com/open-orchestra/open-orchestra-media-bundle/pull/166
https://github.com/open-orchestra/open-orchestra-elastica-bundle/pull/17
https://github.com/open-orchestra/open-orchestra-elastica-bundle/pull/18
https://github.com/open-orchestra/open-orchestra-media-admin-bundle/pull/159
https://github.com/open-orchestra/open-orchestra-user-bundle/pull/92
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1457
