### PR TITLE
Move getCacheTags from AbstractStrategy to implementing strategies

### DIFF
--- a/ElasticaAdmin/DisplayBlock/ElasticaSearchStrategy.php
+++ b/ElasticaAdmin/DisplayBlock/ElasticaSearchStrategy.php
@@ -39,6 +39,16 @@ class ElasticaSearchStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string


### PR DESCRIPTION
[OO-BCBREAK] DisplayBundle/DisplayBlock/Strategies/AbstractStrategy:getCacheTags() is now abstract and must therefore be explicitally implemented on each display strategy
https://github.com/open-orchestra/open-orchestra-display-bundle/pull/200
https://github.com/open-orchestra/open-orchestra-media-bundle/pull/166
https://github.com/open-orchestra/open-orchestra-elastica-bundle/pull/17
https://github.com/open-orchestra/open-orchestra-elastica-bundle/pull/18
https://github.com/open-orchestra/open-orchestra-media-admin-bundle/pull/159
https://github.com/open-orchestra/open-orchestra-user-bundle/pull/92
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1457
