### PR TITLE
rename ElasticaSchemaInitializer by ElasticaSchemaInitializerInterface

### DIFF
--- a/Elastica/SchemaInitializer/ElasticaSchemaInitializer.php
+++ b/Elastica/SchemaInitializer/ElasticaSchemaInitializer.php
@@ -2,8 +2,12 @@
 
 namespace OpenOrchestra\Elastica\SchemaInitializer;
 
+@trigger_error('The '.__NAMESPACE__.'\ElasticaSchemaInitializer class is deprecated since version 1.2.0 and will be removed in 1.3.0, it is replace by ElasticaSchemaInitializerInterface', E_USER_DEPRECATED);
+
 /**
  * Interface ElasticaSchemaInitializer
+ *
+ * @deprecated use the ElasticaSchemaInitializerInterface instead, will be removed in 1.3.0
  */
 interface ElasticaSchemaInitializer
 {

--- a/Elastica/SchemaInitializer/ElasticaSchemaInitializerInterface.php
+++ b/Elastica/SchemaInitializer/ElasticaSchemaInitializerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OpenOrchestra\Elastica\SchemaInitializer;
+
+/**
+ * Interface ElasticaSchemaInitializerInterface
+ */
+interface ElasticaSchemaInitializerInterface
+{
+    /**
+     * Initialize the elastica schema for an object
+     */
+    public function initialize();
+}

--- a/Elastica/SchemaInitializer/SchemaInitializerManager.php
+++ b/Elastica/SchemaInitializer/SchemaInitializerManager.php
@@ -5,14 +5,14 @@ namespace OpenOrchestra\Elastica\SchemaInitializer;
 /**
  * Class SchemaInitializerManager
  */
-class SchemaInitializerManager implements ElasticaSchemaInitializer
+class SchemaInitializerManager implements ElasticaSchemaInitializerInterface
 {
     protected $initializers = array();
 
     /**
-     * @param ElasticaSchemaInitializer $initializer
+     * @param ElasticaSchemaInitializerInterface $initializer
      */
-    public function addInitializer(ElasticaSchemaInitializer $initializer)
+    public function addInitializer(ElasticaSchemaInitializerInterface $initializer)
     {
         $this->initializers[] = $initializer;
     }
@@ -22,7 +22,7 @@ class SchemaInitializerManager implements ElasticaSchemaInitializer
      */
     public function initialize()
     {
-        /** @var ElasticaSchemaInitializer $initializer */
+        /** @var ElasticaSchemaInitializerInterface $initializer */
         foreach ($this->initializers as $initializer) {
             $initializer->initialize();
         }

--- a/Elastica/SchemaInitializer/Strategies/ContentTypeSchemaInitializer.php
+++ b/Elastica/SchemaInitializer/Strategies/ContentTypeSchemaInitializer.php
@@ -3,13 +3,13 @@
 namespace OpenOrchestra\Elastica\SchemaInitializer\Strategies;
 
 use OpenOrchestra\Elastica\SchemaGenerator\DocumentToElasticaSchemaGeneratorInterface;
-use OpenOrchestra\Elastica\SchemaInitializer\ElasticaSchemaInitializer;
+use OpenOrchestra\Elastica\SchemaInitializer\ElasticaSchemaInitializerInterface;
 use OpenOrchestra\ModelInterface\Repository\ContentTypeRepositoryInterface;
 
 /**
  * Class ContentTypeSchemaInitializer
  */
-class ContentTypeSchemaInitializer implements ElasticaSchemaInitializer
+class ContentTypeSchemaInitializer implements ElasticaSchemaInitializerInterface
 {
     protected $contentTypeRepository;
     protected $schemaGenerator;

--- a/Elastica/Tests/SchemaInitializer/SchemaInitializerManagerTest.php
+++ b/Elastica/Tests/SchemaInitializer/SchemaInitializerManagerTest.php
@@ -2,7 +2,7 @@
 
 namespace OpenOrchestra\Elastica\Tests\SchemaInitializer;
 
-use OpenOrchestra\Elastica\SchemaInitializer\ElasticaSchemaInitializer;
+use OpenOrchestra\Elastica\SchemaInitializer\ElasticaSchemaInitializerInterface;
 use OpenOrchestra\Elastica\SchemaInitializer\SchemaInitializerManager;
 use Phake;
 
@@ -37,7 +37,7 @@ class SchemaInitializerManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testInitialize()
     {
-        $initializer = Phake::mock(ElasticaSchemaInitializer::CLASS);
+        $initializer = Phake::mock(ElasticaSchemaInitializerInterface::CLASS);
         $this->manager->addInitializer($initializer);
         $this->manager->addInitializer($initializer);
 

--- a/Elastica/Tests/SchemaInitializer/Strategies/ContentTypeSchemaInitializerTest.php
+++ b/Elastica/Tests/SchemaInitializer/Strategies/ContentTypeSchemaInitializerTest.php
@@ -3,7 +3,7 @@
 namespace OpenOrchestra\Elastica\Tests\SchemaInitializer\Strategies;
 
 use OpenOrchestra\Elastica\SchemaGenerator\DocumentToElasticaSchemaGeneratorInterface;
-use OpenOrchestra\Elastica\SchemaInitializer\ElasticaSchemaInitializer;
+use OpenOrchestra\Elastica\SchemaInitializer\ElasticaSchemaInitializerInterface;
 use OpenOrchestra\Elastica\SchemaInitializer\Strategies\ContentTypeSchemaInitializer;
 use OpenOrchestra\ModelInterface\Model\ContentTypeInterface;
 use OpenOrchestra\ModelInterface\Repository\ContentTypeRepositoryInterface;
@@ -38,7 +38,7 @@ class ContentTypeSchemaInitializerTest extends \PHPUnit_Framework_TestCase
      */
     public function testInstance()
     {
-        $this->assertInstanceOf(ElasticaSchemaInitializer::CLASS, $this->initializer);
+        $this->assertInstanceOf(ElasticaSchemaInitializerInterface::CLASS, $this->initializer);
     }
 
     /**

--- a/ElasticaAdmin/DisplayBlock/ElasticaListStrategy.php
+++ b/ElasticaAdmin/DisplayBlock/ElasticaListStrategy.php
@@ -42,7 +42,7 @@ class ElasticaListStrategy extends AbstractStrategy
     /**
      * @param ReadBlockInterface $block
      *
-     * @return Array
+     * @return array
      */
     public function getCacheTags(ReadBlockInterface $block)
     {

--- a/ElasticaAdminBundle/DependencyInjection/Configuration.php
+++ b/ElasticaAdminBundle/DependencyInjection/Configuration.php
@@ -18,7 +18,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('open_orchestra_elastica_admin');
+        $treeBuilder->root('open_orchestra_elastica_admin');
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/ElasticaAdminBundle/DependencyInjection/OpenOrchestraElasticaAdminExtension.php
+++ b/ElasticaAdminBundle/DependencyInjection/OpenOrchestraElasticaAdminExtension.php
@@ -22,7 +22,7 @@ class OpenOrchestraElasticaAdminExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
-        $config = $this->processConfiguration($configuration, $configs);
+        $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('open_orchestra_elastica.orchestra_choice.front_language', $container->getParameter('open_orchestra_backoffice.orchestra_choice.front_language'));
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/ElasticaFront/DisplayBlock/ElasticaListStrategy.php
+++ b/ElasticaFront/DisplayBlock/ElasticaListStrategy.php
@@ -59,7 +59,7 @@ class ElasticaListStrategy extends AbstractStrategy
 
         $data = $request->get('elastica_search');
         $searchData = array();
-        if (is_array($data) && array_key_exists('search', $data) && null != $data['search']) {
+        if (is_array($data) && array_key_exists('search', $data) && null !== $data['search']) {
             $searchParameter = $data['search'];
 
             $index = $this->client->getIndex($this->indexName);
@@ -85,7 +85,7 @@ class ElasticaListStrategy extends AbstractStrategy
     /**
      * @param ReadBlockInterface $block
      *
-     * @return Array
+     * @return array
      */
     public function getCacheTags(ReadBlockInterface $block)
     {

--- a/ElasticaFrontBundle/DependencyInjection/Configuration.php
+++ b/ElasticaFrontBundle/DependencyInjection/Configuration.php
@@ -18,7 +18,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('open_orchestra_elastica_front');
+        $treeBuilder->root('open_orchestra_elastica_front');
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/ElasticaFrontBundle/DependencyInjection/OpenOrchestraElasticaFrontExtension.php
+++ b/ElasticaFrontBundle/DependencyInjection/OpenOrchestraElasticaFrontExtension.php
@@ -20,7 +20,7 @@ class OpenOrchestraElasticaFrontExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
-        $config = $this->processConfiguration($configuration, $configs);
+        $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('open_orchestra_elastica.orchestra_choice.front_language', array());
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));


### PR DESCRIPTION
[OO-DEPRECATED] ElasticaSchemaInitializer class is deprecated since version 1.2.0 and will be removed in 1.3.0, it is replace by ElasticaSchemaInitializerInterface
