### PR TITLE
add default max age

### DIFF
--- a/ElasticaAdmin/GenerateForm/ElasticaListStrategy.php
+++ b/ElasticaAdmin/GenerateForm/ElasticaListStrategy.php
@@ -32,13 +32,14 @@ class ElasticaListStrategy extends AbstractBlockStrategy
     }
 
     /**
-     * Get the default configuration for the block
-     *
      * @return array
      */
     public function getDefaultConfiguration()
     {
-        return array('searchLimit' => 10);
+        return array(
+                'maxAge' => 0,
+                'searchLimit' => 10
+        );
     }
 
     /**

--- a/ElasticaAdmin/GenerateForm/ElasticaListStrategy.php
+++ b/ElasticaAdmin/GenerateForm/ElasticaListStrategy.php
@@ -37,8 +37,8 @@ class ElasticaListStrategy extends AbstractBlockStrategy
     public function getDefaultConfiguration()
     {
         return array(
-                'maxAge' => 0,
-                'searchLimit' => 10
+            'maxAge' => 0,
+            'searchLimit' => 10
         );
     }
 

--- a/ElasticaAdmin/Tests/GenerateForm/ElasticaListStrategyTest.php
+++ b/ElasticaAdmin/Tests/GenerateForm/ElasticaListStrategyTest.php
@@ -74,7 +74,7 @@ class ElasticaListStrategyTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetDefaultConfiguration()
     {
-        $this->assertSame(array('searchLimit' => 10), $this->strategy->getDefaultConfiguration());
+        $this->assertSame(array('maxAge' => 0, 'searchLimit' => 10), $this->strategy->getDefaultConfiguration());
     }
 
     /**

--- a/ElasticaAdmin/Tests/GenerateForm/ElasticaListStrategyTest.php
+++ b/ElasticaAdmin/Tests/GenerateForm/ElasticaListStrategyTest.php
@@ -23,7 +23,7 @@ class ElasticaListStrategyTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->strategy = new ElasticaListStrategy();
+        $this->strategy = new ElasticaListStrategy(array());
     }
 
     /**

--- a/ElasticaAdmin/Tests/GenerateForm/ElasticaSearchStrategyTest.php
+++ b/ElasticaAdmin/Tests/GenerateForm/ElasticaSearchStrategyTest.php
@@ -24,7 +24,7 @@ class ElasticaSearchStrategyTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->strategy = new ElasticaSearchStrategy();
+        $this->strategy = new ElasticaSearchStrategy(array());
     }
 
     /**

--- a/ElasticaAdminBundle/Resources/config/generate_form.yml
+++ b/ElasticaAdminBundle/Resources/config/generate_form.yml
@@ -5,9 +5,13 @@ parameters:
 services:
     open_orchestra_elastica_admin.generate_form.search:
         class: '%open_orchestra_elastica_admin.generate_form.search.class%'
+        arguments:
+            - '%open_orchestra_backoffice.block_default_configuration%'
         tags:
             - { name: open_orchestra_backoffice.generate_form.strategy }
     open_orchestra_elastica_admin.generate_form.list:
         class: '%open_orchestra_elastica_admin.generate_form.list.class%'
+        arguments:
+            - '%open_orchestra_backoffice.block_default_configuration%'
         tags:
             - { name: open_orchestra_backoffice.generate_form.strategy }


### PR DESCRIPTION
[OO-FEATURE] add default max age to 600s in block form strategies
[OO-BCBREAK] Adding new parameter open_orchestra_backoffice.block_default_configuration for block form strategies

https://github.com/open-orchestra/open-orchestra-media-admin-bundle/pull/278
https://github.com/open-orchestra/open-orchestra-elastica-bundle/pull/52
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1843
